### PR TITLE
feat: Implement dark mode for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Django
+assest/
+*.log
+*.pot
+*.pyc
+__pycache__/
+db.sqlite3
+/media/
+/static_root/
+
+# Python
+*.Python
+env/
+venv/
+ENV/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# IDEs
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1,0 +1,73 @@
+/* static/css/dark-mode.css */
+
+body.dark-mode {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+body.dark-mode #nav {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+body.dark-mode #logo h1{
+    color: #e0e0e0;
+}
+
+body.dark-mode .nav-link h3 {
+    color: #e0e0e0;
+}
+
+body.dark-mode #page1,
+body.dark-mode #page2,
+body.dark-mode #page3 {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+body.dark-mode .input-group input,
+body.dark-mode .input-group select { /* Assuming selects might also need styling */
+    background-color: #2c2c2c;
+    color: #e0e0e0;
+    border: 1px solid #3c3c3c;
+}
+
+body.dark-mode button,
+body.dark-mode .dropbtn, /* Style for existing dropdown buttons */
+body.dark-mode input[type="submit"] /* Style for submit inputs that look like buttons */ {
+    background-color: #333333;
+    color: #e0e0e0;
+    border: 1px solid #444444;
+}
+
+body.dark-mode button:hover,
+body.dark-mode .dropbtn:hover,
+body.dark-mode input[type="submit"]:hover {
+    background-color: #444444;
+}
+
+body.dark-mode .dropdown-content {
+    background-color: #1e1e1e;
+}
+
+body.dark-mode .dropdown-content a {
+    color: #e0e0e0;
+}
+
+body.dark-mode .dropdown-content a:hover {
+    background-color: #333333;
+}
+
+/* Add specific styles for prediction page elements if needed */
+body.dark-mode .container {
+    background-color: #1e1e1e; /* Or #121212 if you want it same as body */
+    color: #e0e0e0;
+}
+
+body.dark-mode .result-container p {
+    color: #e0e0e0;
+}
+
+body.dark-mode label {
+    color: #e0e0e0;
+}

--- a/static/js/theme-switcher.js
+++ b/static/js/theme-switcher.js
@@ -1,0 +1,33 @@
+// static/js/theme-switcher.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+
+    // Function to apply theme based on preference
+    const applyTheme = (theme) => {
+        if (theme === 'dark') {
+            body.classList.add('dark-mode');
+        } else {
+            body.classList.remove('dark-mode');
+        }
+    };
+
+    // Check local storage for theme preference on page load
+    const currentTheme = localStorage.getItem('theme');
+    if (currentTheme) {
+        applyTheme(currentTheme);
+    }
+
+    // Event listener for the toggle button
+    if (darkModeToggle) {
+        darkModeToggle.addEventListener('click', () => {
+            body.classList.toggle('dark-mode');
+            let theme = 'light';
+            if (body.classList.contains('dark-mode')) {
+                theme = 'dark';
+            }
+            localStorage.setItem('theme', theme);
+        });
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <title> Medic {% block title%}  {% endblock title %}</title>
     {% block extra_head %}{% endblock %}
     <link rel="stylesheet" href="{% static '/css/style.css' %}">
+    <link rel="stylesheet" href="{% static 'css/dark-mode.css' %}">
 </head>
 <body>
     <div id="full-container">
@@ -38,11 +39,13 @@
                     </a>
                 {% endif %}
                 </div>
+                <button id="darkModeToggle" class="dropbtn">Toggle Dark Mode</button>
             </div>
     </div>
     {% block content %}
 
     {% endblock content %}
     </div>
+    <script src="{% static 'js/theme-switcher.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a dark mode option to the website, toggleable via a button in the navigation bar.

Key changes:
- Created `static/css/dark-mode.css` to house the styles for the dark theme.
- Added a "Toggle Dark Mode" button to `templates/base.html` in the navbar.
- Implemented `static/js/theme-switcher.js` to:
    - Toggle a `dark-mode` class on the `body` element.
    - Store your theme preference (light/dark) in `localStorage`.
    - Apply the stored theme on page load.
- Linked `dark-mode.css` in `templates/base.html` after the main `style.css`.
- Populated `dark-mode.css` with styles for common elements to ensure a consistent dark theme across pages.

A simulated test based on code review indicates the core functionality should work as expected. However, thorough visual testing by a human is recommended to confirm complete visual correctness and address any potential styling gaps or inconsistencies across all pages and UI states.